### PR TITLE
Register the custom admin site properly using apps.py

### DIFF
--- a/ratelimitbackend/admin.py
+++ b/ratelimitbackend/admin.py
@@ -29,9 +29,3 @@ class RateLimitAdminSite(AdminSite):  # noqa
             'template_name': self.login_template or 'admin/login.html',
         }
         return login(request, **defaults)
-
-
-site = RateLimitAdminSite()
-
-for model, admin in django_site._registry.items():
-    site.register(model, admin.__class__)

--- a/ratelimitbackend/apps.py
+++ b/ratelimitbackend/apps.py
@@ -1,0 +1,4 @@
+from django.contrib.admin.apps import AdminConfig
+
+class RateLimitBackendConfig(AdminConfig):
+    default_site = 'ratelimitbackend.admin.RateLimitAdminSite'


### PR DESCRIPTION
Instead of re-registering all the admin sites and models sites into the custom admin site, do what is recommended by the documentation at https://docs.djangoproject.com/en/3.0/ref/contrib/admin/#overriding-the-default-admin-site.
@cpennington Please review