### PR TITLE
Remove usage of django.utils.six and Python2 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python: 3.6
 sudo: false
 env:
-  - TOXENV=py27-django111
   - TOXENV=py34-django111
   - TOXENV=py35-django111
   - TOXENV=py36-django111

--- a/ratelimitbackend/__init__.py
+++ b/ratelimitbackend/__init__.py
@@ -1,1 +1,3 @@
-__version__ = '2.0'
+__version__ = '2.0.1'
+
+default_app_config = 'ratelimitbackend.apps.DjangoRatelimitBackendConfig'

--- a/ratelimitbackend/admin.py
+++ b/ratelimitbackend/admin.py
@@ -1,37 +1,5 @@
 # Allow transitive imports, e.g.
 # `from ratelimitbackend import admin; admin.ModelAdmin`
 from django.contrib.admin import *  # noqa
-from django.contrib.admin import site as django_site
-from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.utils.translation import ugettext as _
 
-from .forms import AdminAuthenticationForm
-from .views import login
-
-
-class RateLimitAdminSite(AdminSite):  # noqa
-    def login(self, request, extra_context=None):
-        """
-        Displays the login form for the given HttpRequest.
-        """
-        context = {
-            'title': _('Log in'),
-            'app_path': request.get_full_path(),
-        }
-        if (REDIRECT_FIELD_NAME not in request.GET and
-                REDIRECT_FIELD_NAME not in request.POST):
-            context[REDIRECT_FIELD_NAME] = request.get_full_path()
-        context.update(extra_context or {})
-        defaults = {
-            'extra_context': context,
-            'current_app': self.name,
-            'authentication_form': self.login_form or AdminAuthenticationForm,
-            'template_name': self.login_template or 'admin/login.html',
-        }
-        return login(request, **defaults)
-
-
-site = RateLimitAdminSite()
-
-for model, admin in django_site._registry.items():
-    site.register(model, admin.__class__)
+from .apps import site

--- a/ratelimitbackend/apps.py
+++ b/ratelimitbackend/apps.py
@@ -1,0 +1,39 @@
+from django.contrib.admin import AdminSite
+from django.apps.config import AppConfig
+from django.utils.translation import ugettext as _
+
+class DjangoRatelimitBackendConfig(AppConfig):
+    name = 'ratelimitbackend'
+
+    def ready(self):
+        from django.contrib.admin import site as django_site
+        for model, admin in django_site._registry.items():
+            site.register(model, admin.__class__)
+
+
+class RateLimitAdminSite(AdminSite):  # noqa
+    def login(self, request, extra_context=None):
+        """
+        Displays the login form for the given HttpRequest.
+        """
+        from .forms import AdminAuthenticationForm
+        from .views import login
+        from django.contrib.auth import REDIRECT_FIELD_NAME
+        context = {
+            'title': _('Log in'),
+            'app_path': request.get_full_path(),
+        }
+        if (REDIRECT_FIELD_NAME not in request.GET and
+                REDIRECT_FIELD_NAME not in request.POST):
+            context[REDIRECT_FIELD_NAME] = request.get_full_path()
+        context.update(extra_context or {})
+        defaults = {
+            'extra_context': context,
+            'current_app': self.name,
+            'authentication_form': self.login_form or AdminAuthenticationForm,
+            'template_name': self.login_template or 'admin/login.html',
+        }
+        return login(request, **defaults)
+
+
+site = RateLimitAdminSite()

--- a/ratelimitbackend/views.py
+++ b/ratelimitbackend/views.py
@@ -3,11 +3,11 @@ from django.contrib.auth import REDIRECT_FIELD_NAME, login as auth_login
 from django.contrib.sites.shortcuts import get_current_site
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
-from django.utils.six.moves.urllib.parse import urlparse
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.debug import sensitive_post_parameters
 
+from urllib.parse import urlparse
 from .forms import AuthenticationForm
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-	py{27,34,35,36}-django111,
+	py{34,35,36}-django111,
 	py{34,35,36}-django20,
 	py{35,36}-django21,
 	docs, lint


### PR DESCRIPTION
### Description
- Usage of `django.utils.six` is causing failures in `Django30`. To fix this issue, we need to replace the usage of `django.utils.six.moves.urllib` with `urllib`. But this change doesn't supports `Python2` so we also need to drop support for `Python2`.
- created a new tag `v2.0.1a6` against this commit to be used in [fixing test failures](https://github.com/edx/edx-platform/pull/28578) for `Django30` in edx-platform.
- Since the branch was created from the previous tag `v2.0.1a5` and those changes haven't been merged in master yet so this PR also includes those changes in it.

### Notes
- As per Jeremy's discussion on https://github.com/brutasse/django-ratelimit-backend/issues/53 and mentioned in the https://github.com/edx/edx-platform/blob/master/docs/decisions/0009_simplify_ratelimiting.rst, we've stopped the usage of this fork. 
- https://github.com/edx/edx-platform/pull/26487 removed the usage of `django-ratelimit-backend` fork from `edx-platform` and now we only have some usage of `django-ratelimit-backend` left in the middlewares. 